### PR TITLE
Added `Redraw.py` (Port `Basics` / `Structure` / `Redraw`)

### DIFF
--- a/Basics/Structure/Redraw/Redraw.py
+++ b/Basics/Structure/Redraw/Redraw.py
@@ -1,0 +1,41 @@
+"""
+Redraw. 
+  
+The redraw() function makes draw() execute once.    
+In this example, draw() is executed once every time 
+the mouse is clicked. 
+"""
+
+from mewnala import *
+
+y = 180
+
+def setup():
+    """ 
+    The statements in the setup() function 
+    execute once when the program begins.
+    """
+    size(640, 360)    # Size should be the first statement
+    stroke(255)         # Set line drawing color to white
+    no_loop()
+
+
+def draw():
+    """
+    The statements in draw() are executed until the
+    program is stopped. Each statement is executed in
+    sequence and after the last line is read, the first
+    line is executed again.
+    """
+    global y
+    background(0)     # Set the background to black
+    y = y - 4
+    if (y < 0):
+        y = height
+    line(0, y, width, y)
+
+
+def mouse_pressed():
+    redraw()
+
+run()


### PR DESCRIPTION
This port is based on the [Python mode redraw example](https://github.com/jdf/processing.py/blob/master/mode/examples/Basics/Structure/Redraw/Redraw.pyde) with only minor changes (camel to snake case) which was itself based on the Java example. It is functional as is.

Fixes https://github.com/processing/processing-examples-mewnala/issues/109